### PR TITLE
Initial commit for ebpf sample code

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -2,8 +2,11 @@ exports_files(["someData.txt"])
 
 cc_library(
     name = "ebpd",
-    srcs = ["ebpd.cc"],
+    srcs = ["ebpd_sample.c",
+            "ebpd_private.h"],
     hdrs = ["ebpd.h"],
+    copts = ["--target=bpf"],
+    deps = ["@libbpf"],
     visibility = [
         "//visibility:public"
     ],

--- a/lib/ebpd.cc
+++ b/lib/ebpd.cc
@@ -1,2 +1,0 @@
-#include "lib/ebpd.h"
-

--- a/lib/ebpd_private.h
+++ b/lib/ebpd_private.h
@@ -1,0 +1,11 @@
+#ifndef EBPD_PRIVATE_H_
+#define EBPD_PRIVATE_H_
+
+#include "include/uapi/linux/bpf.h"
+
+#ifndef __section
+#define __section(NAME)                  \
+   __attribute__((section(NAME), used))
+#endif
+
+#endif

--- a/lib/ebpd_sample.c
+++ b/lib/ebpd_sample.c
@@ -1,0 +1,9 @@
+#include "lib/ebpd.h"
+#include "lib/ebpd_private.h"
+
+__section("xdp")
+int xdp_pass(struct xdp_md *ctx)
+{
+    return XDP_PASS;
+}
+


### PR DESCRIPTION

Tested the ebpd_sample.pic.o obj file and was able to successfully load it into kernel.

closes-jira-bug: CEM-8196

Note: bazel build of //lib:ebpd will fail after this commit due to following linker error.

ERROR: /root/ebpf2/ebplane/lib/BUILD:3:1: Linking of rule '//lib:ebpd' failed (Exit 1) clang failed: error executing command external/llvm_toolchain/bin/clang @bazel-out/k8-fastbuild/bin/lib/libebpd.so-2.params

Use --sandbox_debug to see verbose messages from the sandbox
ld.lld: error: bazel-out/k8-fastbuild/bin/lib/_objs/ebpd/ebpd_sample.pic.o is incompatible with elf_x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)