### PR TITLE
Minimal fix that allows to build libelf.

### DIFF
--- a/third_party/BUILD.elf
+++ b/third_party/BUILD.elf
@@ -5,8 +5,10 @@ filegroup(name = "elfutils_all", srcs = glob(["**"]), visibility = ["//visibilit
 configure_make(
     name = "elfutils",
     configure_options = [
-        "--enable-valgrind",
-        "CC=/usr/bin/gcc",
+        "CC=gcc",
+        "AR=''",
+        "CFLAGS=''",
+	"LDFLAGS=''",
     ],
     lib_source = ":elfutils_all",
     out_lib_dir = "lib",

--- a/third_party/BUILD.elf
+++ b/third_party/BUILD.elf
@@ -4,6 +4,11 @@ filegroup(name = "elfutils_all", srcs = glob(["**"]), visibility = ["//visibilit
 
 configure_make(
     name = "elfutils",
+
+    # elfutils can only be built with gcc. What you see below is a hack:
+    # it overrides the environment variables set by bazel to use clang with
+    # values that force detection and use of the host installed gcc.
+    # TODO: fix the build to be more hermetic.
     configure_options = [
         "CC=gcc",
         "AR=''",


### PR DESCRIPTION
This is PR 1 of N to fix the build environment.

With this change, libelf becomes buildable with the host installed gcc.

How this works:
- bazel is configured to use an hermetic version of llvm clang, downloaded from the llvm repo.
- the libelf rule is passed parameters so we manually override the CC, AR, ... variables configured by bazel to use clang to instead point to a host installed version of gcc.

With this change, the build is no longer hermetic, gcc, m4, make are required to be installed on the host. Follow up changes will make the build hermetic again.