### PR TITLE
Fix build error on systems providing reallocarray.

### DIFF
--- a/third_party/BUILD.bpf
+++ b/third_party/BUILD.bpf
@@ -1,21 +1,21 @@
-COPTS = [
-    '-Iexternal/libbpf/include',
-    '-Iexternal/libbpf/include/uapi',
-    '-DCOMPAT_NEED_REALLOCARRAY',
-    '-fvisibility=hidden',
-    '-Werror',
-    '-Wall',
-]
+load("@rules_foreign_cc//tools/build_defs:make.bzl", "make")
 
-cc_library(
+filegroup(name = "libbpf_all", srcs = glob(["**"]), visibility = ["//visibility:public"])
+
+make(
     name = "libbpf",
-    copts = COPTS,
-    srcs = glob(
-        ["**/*.c"]
-    ),
-    hdrs = glob(
-        ["**/*.h"]
-    ),
-    deps = ["@libelf//:libelf"],
+    make_commands = [
+      "cp -R $$EXT_BUILD_ROOT$$/external/libbpf/include $$INSTALLDIR$$",
+      "BUILD_STATIC_ONLY=y DESTDIR=$$INSTALLDIR$$ INCLUDEDIR=/include LIBDIR=/lib " +
+          "make -C $$EXT_BUILD_ROOT$$/external/libbpf/src install",
+
+      # make commands are concatenated with an & at the end. Either specify
+      # a single command, or keep the wait at the end so the script does not
+      # exit before all commands have completed.
+      # See https://github.com/bazelbuild/rules_foreign_cc/issues/313
+      "wait",
+    ],
+    lib_source = ":libbpf_all",
+    deps = ["@elfutils//:libelf"],
     visibility = ["//visibility:public"],
 )

--- a/third_party/BUILD.elf
+++ b/third_party/BUILD.elf
@@ -3,7 +3,7 @@ load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
 filegroup(name = "elfutils_all", srcs = glob(["**"]), visibility = ["//visibility:public"])
 
 configure_make(
-    name = "elfutils",
+    name = "libelf",
 
     # elfutils can only be built with gcc. What you see below is a hack:
     # it overrides the environment variables set by bazel to use clang with


### PR DESCRIPTION
My libc version provides 'reallocarray', but the libbpf code defaults
to using its local version when the .cc files and .h files are used directly.

This causes the error below. libbpf comes with scripts to detect if reallocarray
is provided or not.

In this change:
- change the BUILD configuration so that it invokes the build scripts
  of libbpf, which will directly detect the capabilities of the libc,
  and define or not reallocarray accordingly.
- also, fixed libbpf to depend on updated elfutils target.

In file included from external/libbpf/src/libbpf.c:41:
external/libbpf/include/tools/libc_compat.h:11:21: error: static declaration of 'reallocarray' follows non-static declaration
static inline void *reallocarray(void *ptr, size_t nmemb, size_t size)
                    ^
/usr/include/stdlib.h:558:14: note: previous declaration is here
extern void *reallocarray (void *__ptr, size_t __nmemb, size_t __size)
             ^