### PR TITLE
ebpd loader changes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,6 +34,14 @@ http_archive(
     strip_prefix = "googletest-release-1.8.1",
 )
 
+http_archive(
+    name = "linuxsrc",
+    url = "https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.15.18.tar.gz",
+    sha256 = "ca13fa5c6e3a6b434556530d92bc1fc86532c2f4f5ae0ed766f6b709322d6495",
+    strip_prefix = "linux-4.15.18",
+    build_file = "//third_party:BUILD.install_linux_hdr",
+)
+
 #############################################################################
 # All rules below are to configure the bazel remote build environment, and bring
 # in clang-8 based toolchains on your system automatically.

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -1,11 +1,20 @@
 cc_library(
     name = "ebpd",
-    srcs = ["ebpd.cc"],
-    hdrs = ["ebpd.h"],
+    srcs = ["ebpd.cc",
+            "ebpd_loader.cc",
+            "ebpd_utils.c",
+            ],
+    hdrs = ["ebpd.h",
+            "ebpd_loader.h",
+            "ebpd_utils.h"
+           ],
+    copts = ["-Iexternal/libbpf/include", ],
     deps = [
         "//lib/ebpf:sample",
+        "@libbpf",
     ],
     visibility = [
         "//visibility:public"
     ],
 )
+

--- a/lib/ebpd_loader.cc
+++ b/lib/ebpd_loader.cc
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <string>
+#include "lib/ebpd_utils.h"
+#include "lib/ebpd_loader.h"
+#include "lib/ebpd.h"
+
+using namespace std;
+
+int
+EbpdLoader::LoadFile(const char *filepath, int ifindex) {
+    int ret;
+    ret = ebpd_load_xdp_prog(filepath, ifindex, &handle);
+    if (ret) {
+        cout << "Error: eBPF program " << filepath << " load failed " << ret << "\n";
+        return ret;
+    }
+    cout << "eBPF program load succeeded, obj: " << handle << "\n";
+    return 0;
+}
+
+int
+EbpdLoader::LoadBuffer(void *buf, int buf_size, const char *name) {
+    int ret;
+    ret = ebpd_load_xdp_buffer(buf, buf_size, name, &handle);
+    if (ret) {
+        cout << "Error: eBPF program " << name << " load failed " << ret << "\n";
+        return ret;
+    }
+    cout << "eBPF buffer load succeeded, obj: " << handle << "\n";
+    return 0;
+}
+
+EbpdLoader::~EbpdLoader() {
+    if (handle) {
+        ebpd_unload(handle);
+        cout << "eBPF program unloaded, obj: " << handle << "\n";
+    }
+}
+

--- a/lib/ebpd_loader.h
+++ b/lib/ebpd_loader.h
@@ -1,0 +1,14 @@
+#ifndef __EBPD_LOADER_H_
+#define __EBPD_LOADER_H_
+
+class EbpdLoader {
+    public:
+        EbpdLoader() { }
+        ~EbpdLoader();
+        int LoadFile(const char *filepath, int ifindex);
+        int LoadBuffer(void *buf, int buf_size, const char *name);
+    private:
+        void *handle;
+};
+
+#endif

--- a/lib/ebpd_utils.c
+++ b/lib/ebpd_utils.c
@@ -1,0 +1,56 @@
+#include <linux/err.h>
+#include <string.h>
+#include "bpf/libbpf.h"
+#include "lib/ebpd_utils.h"
+
+int
+ebpd_load_xdp_prog (const char *filepath, int ifindex, void **handle)
+{
+    struct bpf_object *obj = NULL;
+    struct bpf_prog_load_attr load_attr = {
+        .ifindex	= ifindex,
+        .file           = filepath,
+        .prog_type	= BPF_PROG_TYPE_XDP,
+    };
+    int ret, prog_fd = -1;
+
+    ret = bpf_prog_load_xattr(&load_attr, &obj, &prog_fd);
+    if (ret) {
+        printf("Error loading file(%s) (%d): %s\n",
+               filepath, ret, strerror(-ret));
+        return -ret;
+    }
+    *handle = obj;
+    printf("Successfully loaded bpf program\n");
+    return 0;
+}
+
+int
+ebpd_load_xdp_buffer (void *buf, int buf_size, const char *name, void **handle)
+{
+    struct bpf_object *obj = NULL;
+    int ret;
+
+    obj = bpf_object__open_buffer(buf, buf_size, name);
+    if (IS_ERR_OR_NULL(obj)) {
+        return PTR_ERR(obj);
+    }
+    ret = bpf_object__load(obj);
+    switch (ret) {
+    case 0:
+        *handle = obj;
+        break;
+    default:
+        bpf_object__close(obj);
+        break;
+    }
+    return ret;
+}
+
+void
+ebpd_unload (void *handle)
+{
+    struct bpf_object *obj = (struct bpf_object *) handle;
+    bpf_object__close(obj);
+}
+

--- a/lib/ebpd_utils.h
+++ b/lib/ebpd_utils.h
@@ -1,0 +1,30 @@
+#ifndef EBPD_UTILS_H_
+#define EBPD_UTILS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Public utilities which can be used from userspace */
+
+/*
+ * API to load ebpf object code from a file into kernel
+ */
+extern int ebpd_load_xdp_prog (const char *filepath, int ifindex, void **handle);
+
+/*
+ * API to load ebpf object code from a buffer into kernel
+ */
+extern int ebpd_load_xdp_buffer (void *buf, int buf_size, const char *name, void **handle);
+
+/*
+ * API to unload a previously loaded bpf object
+ */
+extern void ebpd_unload (void *handle);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif

--- a/lib/ebpf/BUILD
+++ b/lib/ebpf/BUILD
@@ -6,5 +6,6 @@ cc_ebpf(
     name = "sample",
     srcs = ["sample.c"],
     hdrs = ["utils.h"],
+    copts = ["-g"],
     deps = ["@libbpf"],
 )

--- a/lib/tests/BUILD
+++ b/lib/tests/BUILD
@@ -1,0 +1,19 @@
+load("//build:embed.bzl", "cc_embed")
+load("//build:ebpf.bzl", "cc_ebpf")
+
+cc_ebpf(
+  name = "ebpf_sample",
+  srcs = ["testdata/ebpf_sample.c"],
+  deps = ["@libbpf"],
+)
+
+cc_test(
+    name = "ebpd_loader_test",
+    srcs = ["ebpd_loader_test.cc"],
+    deps = [
+        "//lib:ebpd",
+        "@gtest//:gtest_main",
+        ":ebpf_sample",
+    ]
+)
+

--- a/lib/tests/ebpd_loader_test.cc
+++ b/lib/tests/ebpd_loader_test.cc
@@ -1,0 +1,16 @@
+#include "gtest/gtest.h"
+#include "lib/tests/ebpf_sample.h"
+#include "lib/ebpd_loader.h"
+#include <iostream>
+#include <string_view>
+
+using namespace std;
+
+TEST(EbpdLoader, Test1) {
+  // File is in ELF, we cannot really check it. Verify at least it is ELF.
+  EXPECT_EQ(0, ebpf::ebpf_sample.find("\x7f""ELF", 0));
+  cout << "ebpf sample size " << ebpf::ebpf_sample.size() << "\n";
+  EbpdLoader *loader = new EbpdLoader();
+  EXPECT_EQ(0, loader->LoadBuffer((void *)&ebpf::ebpf_sample[0],
+                                  ebpf::ebpf_sample.size(), "ebpf_sample"));
+}

--- a/lib/tests/testdata/ebpf_sample.c
+++ b/lib/tests/testdata/ebpf_sample.c
@@ -1,0 +1,12 @@
+#include "uapi/linux/bpf.h"
+
+#ifndef __section
+#define __section(NAME)                  \
+   __attribute__((section(NAME), used))
+#endif
+
+__section("xdp")
+int xdp_pass(struct xdp_md *ctx)
+{
+    return XDP_PASS;
+}

--- a/third_party/BUILD.bpf
+++ b/third_party/BUILD.bpf
@@ -7,7 +7,8 @@ make(
     make_commands = [
       "cp -R $$EXT_BUILD_ROOT$$/external/libbpf/include $$INSTALLDIR$$",
       "BUILD_STATIC_ONLY=y DESTDIR=$$INSTALLDIR$$ INCLUDEDIR=/include LIBDIR=/lib " +
-          "make -C $$EXT_BUILD_ROOT$$/external/libbpf/src install",
+          "CFLAGS=\"-g -O2 -Werror -Wall -I$$EXT_BUILD_ROOT$$/linuxhdr/include \" " +
+          " make -C $$EXT_BUILD_ROOT$$/external/libbpf/src install",
 
       # make commands are concatenated with an & at the end. Either specify
       # a single command, or keep the wait at the end so the script does not
@@ -16,6 +17,7 @@ make(
       "wait",
     ],
     lib_source = ":libbpf_all",
-    deps = ["@elfutils//:libelf"],
+    deps = [ "@elfutils//:libelf",
+             "@linuxsrc//:installhdr", ],
     visibility = ["//visibility:public"],
 )

--- a/third_party/BUILD.install_linux_hdr
+++ b/third_party/BUILD.install_linux_hdr
@@ -1,0 +1,16 @@
+load("@rules_foreign_cc//tools/build_defs:make.bzl", "make")
+
+filegroup(name = "linuxsrc_all", srcs = glob(["**"]), visibility = ["//visibility:public"])
+
+make(
+    name = "installhdr",
+    make_commands = [
+      "make -C $$EXT_BUILD_ROOT$$/external/linuxsrc headers_install INSTALL_HDR_PATH=$$INSTALLDIR$$",
+      # touch .a file to avoid the error
+      "touch $$INSTALLDIR$$/lib/installhdr.a",
+      "wait",
+    ],
+    lib_source = ":linuxsrc_all",
+    visibility = ["//visibility:public"],
+)
+


### PR DESCRIPTION
This changeset contains the following changes:

- Changes to download the linux src and install the kernel headers
- ebdp_utils.c - wrapper APIs to call the libbpf APIs. Right now the
                 APIs to load/unload ebpf code is available.
                 Loading of ebpf sample code through filepath is tested.
- ebpd_loader.cc - A C++ class to load the ebpd code via the ebpd_utils
                   APIs
- epbd_loader_test.cc - Test code for ebpd_loader.cc

TODO:
 - The buffer load API is failing with the following err
   libbpf: ebpf_sample doesn't provide kernel version
   Error: eBPF program ebpf_sample load failed -4002
 - The libbpf code is being compiled using the system linux headers.
   It should use the headers we provide.
 - Better way to install the headers rather than doing it using the src.