### PR TITLE
Xdp loader changes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,6 +34,18 @@ http_archive(
     strip_prefix = "googletest-release-1.8.1",
 )
 
+#
+# Download the longterm stable kernel version in 4.1x series at the time of
+# writing this;
+# NOTE: This is a moving target
+http_archive(
+    name = "linuxsrc",
+    url = "https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.15.18.tar.gz",
+    sha256 = "ca13fa5c6e3a6b434556530d92bc1fc86532c2f4f5ae0ed766f6b709322d6495",
+    strip_prefix = "linux-4.15.18",
+    build_file = "//third_party:BUILD.install_linux_hdr",
+)
+
 #############################################################################
 # All rules below are to configure the bazel remote build environment, and bring
 # in clang-8 based toolchains on your system automatically.

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -1,11 +1,20 @@
 cc_library(
     name = "ebpd",
-    srcs = ["ebpd.cc"],
-    hdrs = ["ebpd.h"],
+    srcs = ["ebpd.cc",
+            "ebpd_utils.c",
+            "xdp_loader.cc",
+            ],
+    hdrs = ["ebpd.h",
+            "ebpd_utils.h",
+            "xdp_loader.h",
+           ],
+    copts = ["-Iexternal/libbpf/include", ],
     deps = [
         "//lib/ebpf:sample",
+        "@libbpf",
     ],
     visibility = [
         "//visibility:public"
     ],
 )
+

--- a/lib/ebpd_utils.c
+++ b/lib/ebpd_utils.c
@@ -12,9 +12,9 @@ ebpd_load_xdp_prog (const char *filepath, int ifindex, void **handle)
         .file           = filepath,
         .prog_type	= BPF_PROG_TYPE_XDP,
     };
-    int ret, prog_fd = -1;
+    int prog_fd = -1;
 
-    ret = bpf_prog_load_xattr(&load_attr, &obj, &prog_fd);
+    int ret = bpf_prog_load_xattr(&load_attr, &obj, &prog_fd);
     if (ret) {
         printf("Error loading file(%s) (%d): %s\n",
                filepath, ret, strerror(-ret));
@@ -28,15 +28,12 @@ ebpd_load_xdp_prog (const char *filepath, int ifindex, void **handle)
 int
 ebpd_load_xdp_buffer (void *buf, int buf_size, const char *name, void **handle)
 {
-    struct bpf_object *obj = NULL;
-    int ret;
-
-    obj = bpf_object__open_buffer(buf, buf_size, name);
+    struct bpf_object *obj = bpf_object__open_buffer(buf, buf_size, name);
     if (IS_ERR_OR_NULL(obj)) {
         return PTR_ERR(obj);
     }
     printf("BPF buffer opened, obj: %p\n", obj);
-    ret = bpf_object__load(obj);
+    int ret = bpf_object__load(obj);
     switch (ret) {
     case 0:
         *handle = obj;
@@ -51,7 +48,9 @@ ebpd_load_xdp_buffer (void *buf, int buf_size, const char *name, void **handle)
 void
 ebpd_unload (void *handle)
 {
-    struct bpf_object *obj = (struct bpf_object *) handle;
-    bpf_object__close(obj);
+    if (handle) {
+        struct bpf_object *obj = (struct bpf_object *) handle;
+        bpf_object__close(obj);
+    }
 }
 

--- a/lib/ebpd_utils.c
+++ b/lib/ebpd_utils.c
@@ -1,0 +1,57 @@
+#include <linux/err.h>
+#include <string.h>
+#include "bpf/libbpf.h"
+#include "lib/ebpd_utils.h"
+
+int
+ebpd_load_xdp_prog (const char *filepath, int ifindex, void **handle)
+{
+    struct bpf_object *obj = NULL;
+    struct bpf_prog_load_attr load_attr = {
+        .ifindex	= ifindex,
+        .file           = filepath,
+        .prog_type	= BPF_PROG_TYPE_XDP,
+    };
+    int ret, prog_fd = -1;
+
+    ret = bpf_prog_load_xattr(&load_attr, &obj, &prog_fd);
+    if (ret) {
+        printf("Error loading file(%s) (%d): %s\n",
+               filepath, ret, strerror(-ret));
+        return -ret;
+    }
+    *handle = obj;
+    printf("Successfully loaded bpf program\n");
+    return 0;
+}
+
+int
+ebpd_load_xdp_buffer (void *buf, int buf_size, const char *name, void **handle)
+{
+    struct bpf_object *obj = NULL;
+    int ret;
+
+    obj = bpf_object__open_buffer(buf, buf_size, name);
+    if (IS_ERR_OR_NULL(obj)) {
+        return PTR_ERR(obj);
+    }
+    printf("BPF buffer opened, obj: %p\n", obj);
+    ret = bpf_object__load(obj);
+    switch (ret) {
+    case 0:
+        *handle = obj;
+        break;
+    default:
+        bpf_object__close(obj);
+        break;
+    }
+    return ret;
+}
+
+void
+ebpd_unload (void *handle)
+{
+    struct bpf_object *obj = (struct bpf_object *) handle;
+    bpf_object__close(obj);
+}
+

--- a/lib/ebpd_utils.h
+++ b/lib/ebpd_utils.h
@@ -1,0 +1,30 @@
+#ifndef EBPD_UTILS_H_
+#define EBPD_UTILS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Public utilities which can be used from userspace */
+
+/*
+ * API to load ebpf object code from a file into kernel
+ */
+extern int ebpd_load_xdp_prog (const char *filepath, int ifindex, void **handle);
+
+/*
+ * API to load ebpf object code from a buffer into kernel
+ */
+extern int ebpd_load_xdp_buffer (void *buf, int buf_size, const char *name, void **handle);
+
+/*
+ * API to unload a previously loaded bpf object
+ */
+extern void ebpd_unload (void *handle);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif

--- a/lib/ebpd_utils.h
+++ b/lib/ebpd_utils.h
@@ -1,5 +1,5 @@
-#ifndef EBPD_UTILS_H_
-#define EBPD_UTILS_H_
+#ifndef LIB_EBPD_UTILS_H_
+#define LIB_EBPD_UTILS_H_
 
 #ifdef __cplusplus
 extern "C"

--- a/lib/ebpf/BUILD
+++ b/lib/ebpf/BUILD
@@ -6,5 +6,6 @@ cc_ebpf(
     name = "sample",
     srcs = ["sample.c"],
     hdrs = ["utils.h"],
+    copts = ["-g"],
     deps = ["@libbpf"],
 )

--- a/lib/ebpf/sample.c
+++ b/lib/ebpf/sample.c
@@ -1,6 +1,10 @@
 #include "lib/ebpf/utils.h"
 #include "uapi/linux/bpf.h"
 
+/* kernel version from /usr/include/linux/version.h */
+__section("version")
+__u32 kver = 263349;
+
 __section("xdp")
 int xdp_pass(struct xdp_md *ctx)
 {

--- a/lib/tests/BUILD
+++ b/lib/tests/BUILD
@@ -1,0 +1,13 @@
+load("//build:embed.bzl", "cc_embed")
+load("//build:ebpf.bzl", "cc_ebpf")
+
+cc_test(
+    name = "xdp_loader_test",
+    srcs = ["xdp_loader_test.cc"],
+    deps = [
+        "//lib:ebpd",
+        "@gtest//:gtest_main",
+        "//lib/ebpf:sample",
+    ]
+)
+

--- a/lib/tests/xdp_loader_test.cc
+++ b/lib/tests/xdp_loader_test.cc
@@ -1,0 +1,18 @@
+#include "gtest/gtest.h"
+#include "lib/ebpf/sample.h"
+#include "lib/xdp_loader.h"
+#include <iostream>
+#include <string_view>
+
+using namespace std;
+
+extern const char *argv[];
+
+TEST(XdpLoader, Test1) {
+  // File is in ELF, we cannot really check it. Verify at least it is ELF.
+  EXPECT_EQ(0, ebpf::sample.find("\x7f""ELF", 0));
+  cout << "ebpf sample size " << ebpf::sample.size() << "\n";
+  XdpHandle xdph = LoadXdpBuffer(ebpf::sample, "ebpf_sample");
+  EXPECT_EQ(1, (xdph != nullptr));
+}
+

--- a/lib/xdp_loader.cc
+++ b/lib/xdp_loader.cc
@@ -5,40 +5,40 @@
 #include "lib/ebpd.h"
 #include "lib/xdp_loader.h"
 
+using namespace std;
+
 int
-XdpLoader::LoadFrmFile(const string filepath, const int ifindex) {
-    int ret;
-    ret = ebpd_load_xdp_prog(filepath.c_str(), ifindex, &handle);
+XdpLoader::LoadFrmFile(const string& filepath, const int ifindex) {
+    int ret = ebpd_load_xdp_prog(filepath.c_str(), ifindex, &handle_);
     if (ret) {
         cout << "Error: eBPF program " << filepath << " load failed " << ret << "\n";
         return ret;
     }
-    cout << "eBPF program load succeeded, obj: " << handle << "\n";
+    cout << "eBPF program load succeeded, obj: " << handle_ << "\n";
     return 0;
 }
 
 int
-XdpLoader::LoadFrmBuffer(const string_view buffer, const char *name) {
-    int ret;
-    ret = ebpd_load_xdp_buffer((void *)buffer.data(), buffer.size(), name, &handle);
+XdpLoader::LoadFrmBuffer(const string_view& buffer, const string& name) {
+    int ret = ebpd_load_xdp_buffer((void *)buffer.data(), buffer.size(), name.c_str(), &handle_);
     if (ret) {
         cout << "Error: eBPF program " << name << " load failed " << ret << "\n";
         return ret;
     }
-    cout << "eBPF buffer load succeeded, obj: " << handle << "\n";
+    cout << "eBPF buffer load succeeded, obj: " << handle_ << "\n";
     return 0;
 }
 
 XdpLoader::~XdpLoader() {
-    if (handle) {
-        ebpd_unload(handle);
-        cout << "eBPF program unloaded, obj: " << handle << "\n";
+    if (handle_) {
+        ebpd_unload(handle_);
+        cout << "eBPF program unloaded, obj: " << handle_ << "\n";
     }
 }
 
 XdpHandle
-LoadXdpFile(const string filepath, const int ifindex) {
-    XdpHandle xdph(new XdpLoader());
+LoadXdpFile(const string& filepath, const int ifindex) {
+    XdpHandle xdph = make_unique<XdpLoader>();
     if (xdph->LoadFrmFile(filepath, ifindex) == 0) {
         return xdph;
     }
@@ -46,8 +46,8 @@ LoadXdpFile(const string filepath, const int ifindex) {
 }
 
 XdpHandle
-LoadXdpBuffer(const string_view buffer, const char *name) {
-    XdpHandle xdph(new XdpLoader());
+LoadXdpBuffer(const string_view& buffer, const string& name) {
+    XdpHandle xdph = make_unique<XdpLoader>();
     if (xdph->LoadFrmBuffer(buffer, name) == 0) {
         return xdph;
     }

--- a/lib/xdp_loader.cc
+++ b/lib/xdp_loader.cc
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <string>
+#include <memory>
+#include "lib/ebpd_utils.h"
+#include "lib/ebpd.h"
+#include "lib/xdp_loader.h"
+
+int
+XdpLoader::LoadFrmFile(const string filepath, const int ifindex) {
+    int ret;
+    ret = ebpd_load_xdp_prog(filepath.c_str(), ifindex, &handle);
+    if (ret) {
+        cout << "Error: eBPF program " << filepath << " load failed " << ret << "\n";
+        return ret;
+    }
+    cout << "eBPF program load succeeded, obj: " << handle << "\n";
+    return 0;
+}
+
+int
+XdpLoader::LoadFrmBuffer(const string_view buffer, const char *name) {
+    int ret;
+    ret = ebpd_load_xdp_buffer((void *)buffer.data(), buffer.size(), name, &handle);
+    if (ret) {
+        cout << "Error: eBPF program " << name << " load failed " << ret << "\n";
+        return ret;
+    }
+    cout << "eBPF buffer load succeeded, obj: " << handle << "\n";
+    return 0;
+}
+
+XdpLoader::~XdpLoader() {
+    if (handle) {
+        ebpd_unload(handle);
+        cout << "eBPF program unloaded, obj: " << handle << "\n";
+    }
+}
+
+XdpHandle
+LoadXdpFile(const string filepath, const int ifindex) {
+    XdpHandle xdph(new XdpLoader());
+    if (xdph->LoadFrmFile(filepath, ifindex) == 0) {
+        return xdph;
+    }
+    return nullptr;
+}
+
+XdpHandle
+LoadXdpBuffer(const string_view buffer, const char *name) {
+    XdpHandle xdph(new XdpLoader());
+    if (xdph->LoadFrmBuffer(buffer, name) == 0) {
+        return xdph;
+    }
+    return nullptr;
+}
+

--- a/lib/xdp_loader.h
+++ b/lib/xdp_loader.h
@@ -1,0 +1,31 @@
+#ifndef __XDP_LOADER_H_
+#define __XDP_LOADER_H_
+
+using namespace std;
+
+class XdpLoader {
+    public:
+        XdpLoader(): handle(nullptr) { }
+        ~XdpLoader();
+        int LoadFrmFile(const string filepath, const int ifindex);
+        int LoadFrmBuffer(const string_view buffer, const char *name);
+    private:
+        void *handle;
+};
+
+using XdpHandle = unique_ptr<XdpLoader>;
+
+/*
+ * API to load an xdp program into kernel
+ * file path - path to the xdp object file
+ * ifindex - ifindex to associate the program with
+ */
+XdpHandle LoadXdpFile(const string filepath, const int ifindex);
+/*
+ * API to load an xdp program from buffer into kernel
+ * buffer - buffer containing xdp code
+ * name (optional) - user given program name
+ */
+XdpHandle LoadXdpBuffer(const string_view buffer, const char *name);
+
+#endif

--- a/lib/xdp_loader.h
+++ b/lib/xdp_loader.h
@@ -1,31 +1,29 @@
-#ifndef __XDP_LOADER_H_
-#define __XDP_LOADER_H_
-
-using namespace std;
+#ifndef LIB_XDP_LOADER_H_
+#define LIB_XDP_LOADER_H_
 
 class XdpLoader {
     public:
-        XdpLoader(): handle(nullptr) { }
+        XdpLoader() { };
         ~XdpLoader();
-        int LoadFrmFile(const string filepath, const int ifindex);
-        int LoadFrmBuffer(const string_view buffer, const char *name);
+        int LoadFrmFile(const std::string& filepath, const int ifindex);
+        int LoadFrmBuffer(const std::string_view& buffer, const std::string& name);
     private:
-        void *handle;
+        void *handle_ = nullptr;
 };
 
-using XdpHandle = unique_ptr<XdpLoader>;
+using XdpHandle = std::unique_ptr<XdpLoader>;
 
 /*
  * API to load an xdp program into kernel
  * file path - path to the xdp object file
  * ifindex - ifindex to associate the program with
  */
-XdpHandle LoadXdpFile(const string filepath, const int ifindex);
+XdpHandle LoadXdpFile(const std::string& filepath, const int ifindex);
 /*
  * API to load an xdp program from buffer into kernel
  * buffer - buffer containing xdp code
  * name (optional) - user given program name
  */
-XdpHandle LoadXdpBuffer(const string_view buffer, const char *name);
+XdpHandle LoadXdpBuffer(const std::string_view& buffer, const std::string& name);
 
 #endif

--- a/third_party/BUILD.bpf
+++ b/third_party/BUILD.bpf
@@ -7,7 +7,8 @@ make(
     make_commands = [
       "cp -R $$EXT_BUILD_ROOT$$/external/libbpf/include $$INSTALLDIR$$",
       "BUILD_STATIC_ONLY=y DESTDIR=$$INSTALLDIR$$ INCLUDEDIR=/include LIBDIR=/lib " +
-          "make -C $$EXT_BUILD_ROOT$$/external/libbpf/src install",
+          "CFLAGS=\"-g -O2 -Werror -Wall -I$$EXT_BUILD_ROOT$$/linuxhdr/include \" " +
+          " make -C $$EXT_BUILD_ROOT$$/external/libbpf/src install",
 
       # make commands are concatenated with an & at the end. Either specify
       # a single command, or keep the wait at the end so the script does not
@@ -16,6 +17,7 @@ make(
       "wait",
     ],
     lib_source = ":libbpf_all",
-    deps = ["@elfutils//:libelf"],
+    deps = [ "@elfutils//:libelf",
+             "@linuxsrc//:installhdr", ],
     visibility = ["//visibility:public"],
 )

--- a/third_party/BUILD.install_linux_hdr
+++ b/third_party/BUILD.install_linux_hdr
@@ -1,0 +1,16 @@
+load("@rules_foreign_cc//tools/build_defs:make.bzl", "make")
+
+filegroup(name = "linuxsrc_all", srcs = glob(["**"]), visibility = ["//visibility:public"])
+
+make(
+    name = "installhdr",
+    make_commands = [
+      "make -C $$EXT_BUILD_ROOT$$/external/linuxsrc headers_install INSTALL_HDR_PATH=$$INSTALLDIR$$",
+      # touch .a file to avoid the error
+      "touch $$INSTALLDIR$$/lib/installhdr.a",
+      "wait",
+    ],
+    lib_source = ":linuxsrc_all",
+    visibility = ["//visibility:public"],
+)
+


### PR DESCRIPTION
 closes-jira-bug: CEM-8952   
 
This changeset contains the following changes:

    - Changes to download the linux src and install the kernel headers
    - ebdp_utils.c - wrapper APIs to call the libbpf APIs. Right now the
                     APIs to load/unload ebpf code is available.
                     Loading of ebpf sample code through filepath is tested.
    - xdp_loader.cc - A C++ class to load the ebpf xdp code via the ebpd_utils
                      APIs
    - xdp_loader_test.cc - Test code for xdp_loader.cc

    TODO:
     - The buffer load API is failing with the following err
       libbpf: Error loading BTF: Invalid argument(22)
       libbpf: Error loading .BTF into kernel: -22.
       BPF buffer opened, obj: 0x1db0e00
       libbpf: load bpf program failed: Invalid argument
       libbpf: failed to load program 'xdp'
       libbpf: failed to load object 'ebpf_sample'
       Error: eBPF program ebpf_sample load failed -4009
     - The libbpf code is being compiled using the system linux headers.
       It should use the headers we provide.
     - Better way to install the headers rather than doing it using the src.