### PR TITLE
Change error::Code (from an opaque int) to alias std::error_code

### DIFF
--- a/lib/error/BUILD
+++ b/lib/error/BUILD
@@ -3,17 +3,31 @@
 # should use this library to report errors to the caller.
 cc_library(
     name = "error",
+    srcs = [
+        "errno.cc",
+    ],
     hdrs = [
+        "assign_or_return.h",
+        "code.h",
+        "errno.h",
+        "return_if_error.h",
         "status.h",
         "status_or.h",
-        "return_if_error.h",
-        "assign_or_return.h",
+    ],
+    visibility = [
+        "//visibility:public",
     ],
     deps = [
         "//lib/base",
     ],
-    visibility = [
-        "//visibility:public"
+)
+
+cc_test(
+    name = "errno_test",
+    srcs = ["errno_test.cc"],
+    deps = [
+        "//lib/error",
+        "@gtest//:gtest_main",
     ],
 )
 
@@ -21,8 +35,8 @@ cc_test(
     name = "status_test",
     srcs = ["status_test.cc"],
     deps = [
-	"@gtest//:gtest_main",
-	"//lib/error"
+        "//lib/error",
+        "@gtest//:gtest_main",
     ],
 )
 
@@ -30,8 +44,8 @@ cc_test(
     name = "status_or_test",
     srcs = ["status_or_test.cc"],
     deps = [
-	"@gtest//:gtest_main",
-	"//lib/error"
+        "//lib/error",
+        "@gtest//:gtest_main",
     ],
 )
 
@@ -39,8 +53,8 @@ cc_test(
     name = "return_if_error_test",
     srcs = ["return_if_error_test.cc"],
     deps = [
-	"@gtest//:gtest_main",
-	"//lib/error"
+        "//lib/error",
+        "@gtest//:gtest_main",
     ],
 )
 
@@ -48,7 +62,7 @@ cc_test(
     name = "assign_or_return_test",
     srcs = ["assign_or_return_test.cc"],
     deps = [
-	"@gtest//:gtest_main",
-	"//lib/error"
+        "//lib/error",
+        "@gtest//:gtest_main",
     ],
 )

--- a/lib/error/BUILD
+++ b/lib/error/BUILD
@@ -23,6 +23,15 @@ cc_library(
 )
 
 cc_test(
+    name = "code_test",
+    srcs = ["code_test.cc"],
+    deps = [
+        "//lib/error",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "errno_test",
     srcs = ["errno_test.cc"],
     deps = [

--- a/lib/error/assign_or_return_test.cc
+++ b/lib/error/assign_or_return_test.cc
@@ -1,10 +1,11 @@
 #include "lib/error/assign_or_return.h"
 #include "gtest/gtest.h"
+#include "lib/error/errno.h"
 #include "lib/error/status_or.h"
 
 using namespace error;
 
-const Status kDefault(Code(1), "default");
+const Status kDefault(MakeCodeFromErrno(ECHILD), "default");
 
 TEST(TryAssignTest, CopyableStatusOr) {
   constexpr auto fn = [](StatusOr<int> s) -> StatusOr<int> {

--- a/lib/error/code.h
+++ b/lib/error/code.h
@@ -1,0 +1,40 @@
+#ifndef LIB_ERROR_CODE_H_
+#define LIB_ERROR_CODE_H_
+
+#include <system_error>
+#include <type_traits>
+
+namespace error {
+
+// Strongly typed value used to encode specific errors. Code is not
+// interpreted by the core status utilities with the expection of the default
+// constructed value which is always considered a success.
+//
+// The following helpers exist to check for common conditions:
+// IsOk() and IsError().
+//
+// Until proven otherwise, assume that std::error_code implements all necessary
+// features.
+//
+// When possible, avoid using std::error_code features directly and implement
+// wrappers in this file.
+using Code = std::error_code;
+
+static_assert(std::is_trivially_copyable_v<Code>,
+              "Code should be trivially copiable");
+static_assert(16 >= sizeof(Code), "Code seems unreasonably large");
+
+// Constant that satisfies IsOk(kOkCode) == true.
+const Code kOkCode;
+
+// Idiom to check for OK code.
+// Return true iff code == kOkCode.
+inline bool IsOk(const Code code) { return !static_cast<bool>(code); }
+
+// Idiom to check for error codes.
+// Return true iff code != kOkCode.
+inline bool IsError(const Code code) { return !IsOk(code); }
+
+}  // namespace error
+
+#endif  // LIB_ERROR_CODE_H_

--- a/lib/error/code_test.cc
+++ b/lib/error/code_test.cc
@@ -1,0 +1,22 @@
+#include "gtest/gtest.h"
+#include "lib/error/errno.h"
+
+using namespace error;
+
+class MyCategory : public std::error_category {
+ public:
+  const char* name() const noexcept override { return "MyCategory"; }
+  std::string message(int ev) const noexcept override { return "My Message"; }
+};
+
+TEST(CodeTest, Ok) {
+  EXPECT_TRUE(IsOk(kOkCode));
+  EXPECT_FALSE(IsError(kOkCode));
+}
+
+TEST(CodeTest, CustomCategory) {
+  MyCategory category;
+  std::error_code code(0, category);
+  EXPECT_EQ("MyCategory", category.name());
+  EXPECT_EQ("My Message", code.message());
+}

--- a/lib/error/errno.cc
+++ b/lib/error/errno.cc
@@ -1,0 +1,9 @@
+#include "lib/error/errno.h"
+
+#include <cerrno>
+
+namespace error {
+
+Code CaptureErrnoAsCode() { return MakeCodeFromErrno(errno); }
+
+}  // namespace error

--- a/lib/error/errno.h
+++ b/lib/error/errno.h
@@ -1,0 +1,42 @@
+#ifndef LIB_ERROR_ERRNO_H_
+#define LIB_ERROR_ERRNO_H_
+
+#include "lib/error/code.h"
+#include "lib/error/status.h"
+
+namespace error {
+
+// Convert a numeric constant from the system errno.h and friends into a Code.
+inline Code MakeCodeFromErrno(const int e) {
+  return std::system_error(e, std::generic_category()).code();
+}
+
+// Idiom to capture 'errno' and construct a Code using that value.
+//
+// CaptureErrnoAsCode() is definied in errno.cc to keep the 'errno' macro out of
+// header files whenever possible.
+Code CaptureErrnoAsCode();
+
+// Idiom to capture 'errno' and construct a Status using that value and 'text'.
+inline Status CaptureErrnoAsStatus(const std::string_view text) {
+  return Status(CaptureErrnoAsCode(), text);
+}
+
+// Idiom to capture 'errno' and construct a Status using that value and 'text'
+// if 'predicate' is true, return kOkStatus otherwise.
+//
+// Example usage:
+//
+// Status Close(const posix::file_descriptor fd) {
+//   const auto rv = ::close(GetValue(fd));
+//   return OkStatusOrCaptureErrnoIf(0 != rv, "close() failed");
+// }
+//
+inline Status OkStatusOrCaptureErrnoIf(const bool predicate,
+                                       const std::string_view text) {
+  return predicate ? CaptureErrnoAsStatus(text) : kOkStatus;
+}
+
+}  // namespace error
+
+#endif  // LIB_ERROR_ERRNO_H_

--- a/lib/error/errno_test.cc
+++ b/lib/error/errno_test.cc
@@ -1,0 +1,22 @@
+#include "lib/error/errno.h"
+#include <iostream>
+#include "gtest/gtest.h"
+
+using namespace error;
+
+TEST(ErrnoTest, MakeCodeFromErrno) {
+  EXPECT_EQ(std::make_error_code(std::errc::interrupted),
+            MakeCodeFromErrno(EINTR));
+}
+
+TEST(ErrnoTest, OkStatusOrCaptureErrnoIfOk) {
+  EXPECT_EQ(kOkStatus, OkStatusOrCaptureErrnoIf(false, "unused"));
+}
+
+TEST(ErrnoTest, OkStatusOrCaptureErrnoIfError) {
+  errno = EINVAL;
+  const auto status = OkStatusOrCaptureErrnoIf(true, "some error");
+  std::cout << GetCode(status) << "\n";
+  EXPECT_TRUE(IsError(status));
+  EXPECT_EQ("some error", GetText(status));
+}

--- a/lib/error/errno_test.cc
+++ b/lib/error/errno_test.cc
@@ -1,5 +1,4 @@
 #include "lib/error/errno.h"
-#include <iostream>
 #include "gtest/gtest.h"
 
 using namespace error;
@@ -16,7 +15,6 @@ TEST(ErrnoTest, OkStatusOrCaptureErrnoIfOk) {
 TEST(ErrnoTest, OkStatusOrCaptureErrnoIfError) {
   errno = EINVAL;
   const auto status = OkStatusOrCaptureErrnoIf(true, "some error");
-  std::cout << GetCode(status) << "\n";
   EXPECT_TRUE(IsError(status));
   EXPECT_EQ("some error", GetText(status));
 }

--- a/lib/error/return_if_error_test.cc
+++ b/lib/error/return_if_error_test.cc
@@ -1,11 +1,12 @@
 #include "lib/error/return_if_error.h"
 #include "gtest/gtest.h"
+#include "lib/error/errno.h"
 #include "lib/error/status.h"
 
 using namespace error;
 
-const Status kDefault(Code(1), "default");
-const Status kOther(Code(2), "other");
+const Status kDefault(MakeCodeFromErrno(ENOEXEC), "default");
+const Status kOther(MakeCodeFromErrno(EBADF), "other");
 
 TEST(TryTest, Status) {
   constexpr auto fn = [](const Status s) {

--- a/lib/error/status_or_test.cc
+++ b/lib/error/status_or_test.cc
@@ -1,9 +1,10 @@
-#include "gtest/gtest.h"
 #include "lib/error/status_or.h"
+#include "gtest/gtest.h"
+#include "lib/error/errno.h"
 
 using namespace error;
 
-constexpr Code kCancelled(3);
+const Code kCancelled = MakeCodeFromErrno(E2BIG);
 
 TEST(StatusOrTest, Construct) {
   Status cancelled(kCancelled);

--- a/lib/error/status_test.cc
+++ b/lib/error/status_test.cc
@@ -2,19 +2,20 @@
 #include <limits>
 
 #include "gtest/gtest.h"
+#include "lib/error/errno.h"
 #include "lib/error/status.h"
 
 using namespace error;
 
-std::array<Code, 4> kErrorCodes = {
-    Code(1),
-    Code(-1),
-    Code(std::numeric_limits<int>::min()),
-    Code(std::numeric_limits<int>::max()),
+const std::array<const Code, 4> kErrorCodes = {
+    MakeCodeFromErrno(EPERM),
+    MakeCodeFromErrno(ENOENT),
+    MakeCodeFromErrno(ESRCH),
+    MakeCodeFromErrno(EINTR),
 };
 
-constexpr Code kAborted(1);
-constexpr Code kUnknown(2);
+const Code kAborted = MakeCodeFromErrno(EIO);
+const Code kUnknown = MakeCodeFromErrno(ENXIO);
 
 TEST(StatusTest, CodeIsOk) {
   EXPECT_TRUE(IsOk(kOkCode));
@@ -113,7 +114,6 @@ TEST(StatusTest, GetCode) {
 TEST(StatusTest, GetText) {
   EXPECT_EQ("", GetText(Status(kOkCode)));
   for (const auto code : kErrorCodes) {
-    EXPECT_EQ(std::to_string(GetValue(code)),
-              GetText(Status(code, std::to_string(GetValue(code)))));
+    EXPECT_EQ(code.message(), GetText(Status(code, code.message())));
   }
 }


### PR DESCRIPTION
This change leverages useful default error spaces provided by the
standard library along with the ability to define our own error spaces
in the future.

To retain flexibility in the future, direct use of std::error_code is
discouraged. Users should prefer helpers defined in lib/error/code.h
and lib/error/errno.h. For now error::Status only depends on
error::Code providing overloads of IsOk() and IsError() and a constant
kOkCode.

For now helpers have been added for POSIX errors as they are the first
user of this functionality.

Some extra noise has been introduced by running buildify on modified
bazel BUILD files.