### PR TITLE
Implement posix::FileDescriptor and posix::UniqueFileDescriptor

### DIFF
--- a/lib/base/BUILD
+++ b/lib/base/BUILD
@@ -14,11 +14,13 @@
 cc_library(
     name = "base",
     hdrs = [
+        "ignore.h",
         "invariant.h",
         "opaque_value.h",
+        "unique_value.h",
     ],
     visibility = [
-        "//visibility:public"
+        "//visibility:public",
     ],
 )
 
@@ -26,7 +28,16 @@ cc_test(
     name = "opaque_value_test",
     srcs = ["opaque_value_test.cc"],
     deps = [
-	"@gtest//:gtest_main",
-	"//lib/base"
+        "//lib/base",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "unique_value_test",
+    srcs = ["unique_value_test.cc"],
+    deps = [
+        "//lib/base",
+        "@gtest//:gtest_main",
     ],
 )

--- a/lib/base/ignore.h
+++ b/lib/base/ignore.h
@@ -1,0 +1,13 @@
+#ifndef LIB_BASE_IGNORE_H_
+#define LIB_BASE_IGNORE_H_
+
+namespace base {
+
+// Idiom to ignore an otherwise unused variable or result.
+// Prefer to (void) cast when dealing with [[nodiscard]].
+template <typename T>
+void Ignore(const T&) {}
+
+}  // namespace base
+
+#endif  // LIB_BASE_IGNORE_H_

--- a/lib/base/unique_value.h
+++ b/lib/base/unique_value.h
@@ -90,7 +90,7 @@ class UniqueValue {
   }
 
   // Return true iff this object contains a value.
-  explicit constexpr operator bool() const { return value_; }
+  explicit constexpr operator bool() const { return static_cast<bool>(value_); }
 
  private:
   // Return the contained value.

--- a/lib/base/unique_value.h
+++ b/lib/base/unique_value.h
@@ -1,0 +1,112 @@
+#ifndef LIB_BASE_UNIQUE_VALUE_H_
+#define LIB_BASE_UNIQUE_VALUE_H_
+
+#include <functional>
+#include <optional>
+
+#include "lib/base/invariant.h"
+
+namespace base {
+
+// Type providing std::unique_ptr<>-like functionality for immutable values.
+// The contents of UniqueValue<> may be replaced, but not modified in place.
+//
+// Unlike pointers where nullptr is a special value that indicates invalid
+// contents, every possible value a value object can hold may be valid. This
+// requires additional storage to track validity of the contained value. Despite
+// the required extra state, this is still more efficient than storing values in
+// heap allocated space and behaves more gracefully under memory pressure.
+//
+// In addition to the type of the wrapped value, users must provide a cleanup
+// function object to be called whenever a UniqueValue containing a valid value
+// is destroyed.
+//
+// CleanupFunctionObjectT is a function object implementing the call operator.
+// In C++20 lambdas can be declared in unevaluated contexts 'decltype([](const T
+// value){})' sufficies to declare a cleanup function object. Prior to C++20 a
+// type must be defined:
+//
+// struct CleanupFunctionObject {
+//     void operator()(const T value){
+//         // cleanup 'value', only called with valid 'value'.
+//     };
+// };
+//
+// Example usage:
+//
+// struct CloseFunctionObject { void operator()(const int fd) { close(fd); } };
+// using UniqueFileDescriptor = UniqueValue<int, CloseFunctionObject>;
+// {
+//     UniqueFileDescriptor fd(open("/some/path", FLAGS));
+//     DoSomethingWithFd(GetValue(fd));  // Free function style value access.
+//     DoSomethingElseWithFd(*fd);  // std::unique_ptr style value access.
+// }  // 'fd' leaves scope and is automatically closed!
+//
+// See /lib/posix/unique_file_descriptor.h for a more complete example.
+//
+template <typename T, typename CleanupFunctionObjectT>
+class UniqueValue {
+ public:
+  // Like std::unique_ptr<> default construction results in an empty object.
+  constexpr UniqueValue() = default;
+
+  // Construct a non-empty UniqueValue containing 'value'.
+  explicit constexpr UniqueValue(const T& value) : value_(value) {}
+
+  // Custom move constructor.
+  UniqueValue(UniqueValue&& that) {
+    value_ = std::move(that.value_);
+    that.value_ = std::nullopt;
+  }
+
+  // Custom move assignment operator.
+  UniqueValue& operator=(UniqueValue&& that) {
+    if (value_) {
+      std::invoke(CleanupFunctionObjectT(), *value_);
+    }
+    value_ = std::move(that.value_);
+    that.value_ = std::nullopt;
+    return *this;
+  }
+
+  // No copy constructor.
+  UniqueValue(const UniqueValue&) = delete;
+
+  // No copy assignment operator.
+  UniqueValue& operator=(const UniqueValue&) = delete;
+
+  // Invoke CleanupFunctionObjectT::operator() if this object contains a value.
+  ~UniqueValue() {
+    if (value_) {
+      std::invoke(CleanupFunctionObjectT(), *value_);
+    }
+  }
+
+  // Return the contained value.
+  // Requires that this objects contains a value.
+  constexpr const T& operator*() const {
+    INVARIANT_T(value_);
+    return *value_;
+  }
+
+  // Return true iff this object contains a value.
+  explicit constexpr operator bool() const { return value_; }
+
+ private:
+  // Return the contained value.
+  // Requires that this object contains a value.
+  friend constexpr const T& GetValue(const UniqueValue& unique_value) {
+    INVARIANT_T(unique_value.value_);
+    return *unique_value.value_;
+  }
+
+  // Wrapped value. T may not be able to represent an invalid value in the way
+  // that nullptr implies an invalid value in std::unique_ptr. std::optional<>
+  // provides an extra bit of information to distinguish uninitialized or
+  // vacated values.
+  std::optional<T> value_ = std::nullopt;
+};
+
+}  // namespace base
+
+#endif  // LIB_BASE_UNIQUE_VALUE_H_

--- a/lib/base/unique_value_test.cc
+++ b/lib/base/unique_value_test.cc
@@ -14,6 +14,28 @@ TEST(UniqueValueTest, DefaultConstructor) {
   ASSERT_TRUE(cleanups.empty());
 }
 
+TEST(UniqueValueTest, GetValue) {
+  struct Cleanup {
+    void operator()(const int) {}
+  };
+  ASSERT_EQ(50, GetValue(UniqueValue<int, Cleanup>(50)));
+}
+
+TEST(UniqueValueTest, OperatorStar) {
+  struct Cleanup {
+    void operator()(const int) {}
+  };
+  ASSERT_EQ(50, *(UniqueValue<int, Cleanup>(50)));
+}
+
+TEST(UniqueValueTest, OperatorBool) {
+  struct Cleanup {
+    void operator()(const int) {}
+  };
+  ASSERT_FALSE((UniqueValue<int, Cleanup>()));
+  ASSERT_TRUE((UniqueValue<int, Cleanup>(50)));
+}
+
 TEST(UniqueValueTest, ExplicitValueConstructor) {
   static std::queue<int> cleanups;
   struct Cleanup {

--- a/lib/base/unique_value_test.cc
+++ b/lib/base/unique_value_test.cc
@@ -1,0 +1,76 @@
+#include <queue>
+
+#include "gtest/gtest.h"
+#include "lib/base/unique_value.h"
+
+using namespace base;
+
+TEST(UniqueValueTest, DefaultConstructor) {
+  static std::queue<int> cleanups;
+  struct Cleanup {
+    void operator()(const int value) { cleanups.push(value); }
+  };
+  { UniqueValue<int, Cleanup> uv; }
+  ASSERT_TRUE(cleanups.empty());
+}
+
+TEST(UniqueValueTest, ExplicitValueConstructor) {
+  static std::queue<int> cleanups;
+  struct Cleanup {
+    void operator()(const int value) { cleanups.push(value); }
+  };
+  { UniqueValue<int, Cleanup> uv(10); }  // Cleanup of 'uv' fires here.
+  ASSERT_EQ(1, cleanups.size());
+  ASSERT_EQ(10, cleanups.front());
+}
+
+TEST(UniqueValueTest, MoveConstructor) {
+  static std::queue<int> cleanups;
+  struct Cleanup {
+    void operator()(const int value) { cleanups.push(value); }
+  };
+  {
+    UniqueValue<int, Cleanup> a(10);
+    UniqueValue<int, Cleanup> b(
+        std::move(a));  // Overwrite valid (cleanup expected).
+    UniqueValue<int, Cleanup> c(
+        std::move(b));  // Overwrite valid (cleanup expected).
+    ASSERT_EQ(10, *c);
+    ASSERT_EQ(10, GetValue(c));
+  }  // Cleanup of 'c' fires here.
+  ASSERT_EQ(1, cleanups.size());
+  ASSERT_EQ(10, cleanups.front());
+}
+
+TEST(UniqueValueTest, MoveEmpty) {
+  static std::queue<int> cleanups;
+  struct Cleanup {
+    void operator()(const int value) { cleanups.push(value); }
+  };
+  {
+    UniqueValue<int, Cleanup> a;
+    UniqueValue<int, Cleanup> b(
+        std::move(a));  // Overwrite empty (no cleanup expected).
+    UniqueValue<int, Cleanup> c;
+    c = std::move(b);  // Overwrite empty (no cleanup expected).
+  }
+  ASSERT_TRUE(cleanups.empty());
+}
+
+TEST(UniqueValueTest, MoveAssignmentOperator) {
+  static std::queue<int> cleanups;
+  struct Cleanup {
+    void operator()(const int value) { cleanups.push(value); }
+  };
+  {
+    UniqueValue<int, Cleanup> a(10);
+    UniqueValue<int, Cleanup> b(11);
+    UniqueValue<int, Cleanup> c;
+    b = std::move(a);  // Overwrite valid (cleanup expected).
+    c = std::move(b);  // Overwrite empty (no cleanup expected).
+  }                    // Cleanup of 'c' fires here.
+  ASSERT_EQ(2, cleanups.size());
+  ASSERT_EQ(11, cleanups.front());
+  cleanups.pop();
+  ASSERT_EQ(10, cleanups.front());
+}

--- a/lib/error/BUILD
+++ b/lib/error/BUILD
@@ -3,13 +3,9 @@
 # should use this library to report errors to the caller.
 cc_library(
     name = "error",
-    srcs = [
-        "errno.cc",
-    ],
     hdrs = [
         "assign_or_return.h",
         "code.h",
-        "errno.h",
         "return_if_error.h",
         "status.h",
         "status_or.h",
@@ -27,15 +23,7 @@ cc_test(
     srcs = ["code_test.cc"],
     deps = [
         "//lib/error",
-        "@gtest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "errno_test",
-    srcs = ["errno_test.cc"],
-    deps = [
-        "//lib/error",
+        "//lib/posix",
         "@gtest//:gtest_main",
     ],
 )
@@ -45,6 +33,7 @@ cc_test(
     srcs = ["status_test.cc"],
     deps = [
         "//lib/error",
+        "//lib/posix",
         "@gtest//:gtest_main",
     ],
 )
@@ -54,6 +43,7 @@ cc_test(
     srcs = ["status_or_test.cc"],
     deps = [
         "//lib/error",
+        "//lib/posix",
         "@gtest//:gtest_main",
     ],
 )
@@ -63,6 +53,7 @@ cc_test(
     srcs = ["return_if_error_test.cc"],
     deps = [
         "//lib/error",
+        "//lib/posix",
         "@gtest//:gtest_main",
     ],
 )
@@ -72,6 +63,7 @@ cc_test(
     srcs = ["assign_or_return_test.cc"],
     deps = [
         "//lib/error",
+        "//lib/posix",
         "@gtest//:gtest_main",
     ],
 )

--- a/lib/error/assign_or_return_test.cc
+++ b/lib/error/assign_or_return_test.cc
@@ -1,9 +1,10 @@
 #include "lib/error/assign_or_return.h"
 #include "gtest/gtest.h"
-#include "lib/error/errno.h"
 #include "lib/error/status_or.h"
+#include "lib/posix/errno.h"
 
 using namespace error;
+using namespace posix;
 
 const Status kDefault(MakeCodeFromErrno(ECHILD), "default");
 

--- a/lib/error/code_test.cc
+++ b/lib/error/code_test.cc
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "lib/error/errno.h"
+#include "lib/posix/errno.h"
 
 using namespace error;
 

--- a/lib/error/errno.cc
+++ b/lib/error/errno.cc
@@ -1,9 +1,0 @@
-#include "lib/error/errno.h"
-
-#include <cerrno>
-
-namespace error {
-
-Code CaptureErrnoAsCode() { return MakeCodeFromErrno(errno); }
-
-}  // namespace error

--- a/lib/error/return_if_error_test.cc
+++ b/lib/error/return_if_error_test.cc
@@ -1,9 +1,10 @@
 #include "lib/error/return_if_error.h"
 #include "gtest/gtest.h"
-#include "lib/error/errno.h"
 #include "lib/error/status.h"
+#include "lib/posix/errno.h"
 
 using namespace error;
+using namespace posix;
 
 const Status kDefault(MakeCodeFromErrno(ENOEXEC), "default");
 const Status kOther(MakeCodeFromErrno(EBADF), "other");

--- a/lib/error/status.h
+++ b/lib/error/status.h
@@ -58,7 +58,7 @@ namespace error {
 //   std::cout << GetText(GetNestedStatus(bar_status));  // Print foo_status
 // }
 //
-class Status {
+class [[nodiscard]] Status {
  public:
   constexpr Status() = default;
 
@@ -90,7 +90,7 @@ class Status {
   }
 
   // Default move constructor.
-  Status(Status&&) = default;
+  Status(Status &&) = default;
 
   // Default move assignment operator.
   Status& operator=(Status&&) = default;

--- a/lib/error/status_or_test.cc
+++ b/lib/error/status_or_test.cc
@@ -1,8 +1,9 @@
 #include "lib/error/status_or.h"
 #include "gtest/gtest.h"
-#include "lib/error/errno.h"
+#include "lib/posix/errno.h"
 
 using namespace error;
+using namespace posix;
 
 const Code kCancelled = MakeCodeFromErrno(E2BIG);
 

--- a/lib/error/status_test.cc
+++ b/lib/error/status_test.cc
@@ -1,11 +1,11 @@
 #include <array>
-#include <limits>
 
 #include "gtest/gtest.h"
-#include "lib/error/errno.h"
 #include "lib/error/status.h"
+#include "lib/posix/errno.h"
 
 using namespace error;
+using namespace posix;
 
 const std::array<const Code, 4> kErrorCodes = {
     MakeCodeFromErrno(EPERM),

--- a/lib/posix/BUILD
+++ b/lib/posix/BUILD
@@ -1,0 +1,39 @@
+cc_library(
+    name = "posix",
+    srcs = [
+        "errno.cc",
+    ],
+    hdrs = [
+        "close.h",
+        "errno.h",
+        "file_descriptor.h",
+        "unique_file_descriptor.h",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//lib/base",
+        "//lib/error",
+    ],
+)
+
+cc_test(
+    name = "errno_test",
+    srcs = ["errno_test.cc"],
+    deps = [
+        "//lib/posix",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "unique_file_descriptor_test",
+    srcs = [
+        "unique_file_descriptor_test.cc",
+    ],
+    deps = [
+        "//lib/posix",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/lib/posix/close.h
+++ b/lib/posix/close.h
@@ -1,0 +1,20 @@
+#ifndef LIB_POSIX_CLOSE_H_
+#define LIB_POSIX_CLOSE_H_
+
+#include <errno.h>
+#include <unistd.h>
+
+#include "lib/error/status.h"
+#include "lib/posix/errno.h"
+#include "lib/posix/file_descriptor.h"
+
+namespace posix {
+
+inline ::error::Status Close(const FileDescriptor fd) {
+  const auto rv = ::close(GetValue(fd));
+  return OkStatusOrCaptureErrnoIf(-1 == rv, "close() failed");
+}
+
+}  // namespace posix
+
+#endif  // LIB_POSIX_CLOSE_H_

--- a/lib/posix/errno.cc
+++ b/lib/posix/errno.cc
@@ -1,0 +1,9 @@
+#include "lib/posix/errno.h"
+
+#include <cerrno>
+
+namespace posix {
+
+error::Code CaptureErrnoAsCode() { return MakeCodeFromErrno(errno); }
+
+}  // namespace posix

--- a/lib/posix/errno.h
+++ b/lib/posix/errno.h
@@ -1,13 +1,13 @@
-#ifndef LIB_ERROR_ERRNO_H_
-#define LIB_ERROR_ERRNO_H_
+#ifndef LIB_POSIX_ERRNO_H_
+#define LIB_POSIX_ERRNO_H_
 
 #include "lib/error/code.h"
 #include "lib/error/status.h"
 
-namespace error {
+namespace posix {
 
 // Convert a numeric constant from the system errno.h and friends into a Code.
-inline Code MakeCodeFromErrno(const int e) {
+inline error::Code MakeCodeFromErrno(const int e) {
   return std::system_error(e, std::generic_category()).code();
 }
 
@@ -15,11 +15,11 @@ inline Code MakeCodeFromErrno(const int e) {
 //
 // CaptureErrnoAsCode() is definied in errno.cc to keep the 'errno' macro out of
 // header files whenever possible.
-Code CaptureErrnoAsCode();
+error::Code CaptureErrnoAsCode();
 
 // Idiom to capture 'errno' and construct a Status using that value and 'text'.
-inline Status CaptureErrnoAsStatus(const std::string_view text) {
-  return Status(CaptureErrnoAsCode(), text);
+inline error::Status CaptureErrnoAsStatus(const std::string_view text) {
+  return error::Status(CaptureErrnoAsCode(), text);
 }
 
 // Idiom to capture 'errno' and construct a Status using that value and 'text'
@@ -32,11 +32,11 @@ inline Status CaptureErrnoAsStatus(const std::string_view text) {
 //   return OkStatusOrCaptureErrnoIf(0 != rv, "close() failed");
 // }
 //
-inline Status OkStatusOrCaptureErrnoIf(const bool predicate,
-                                       const std::string_view text) {
-  return predicate ? CaptureErrnoAsStatus(text) : kOkStatus;
+inline error::Status OkStatusOrCaptureErrnoIf(const bool predicate,
+                                              const std::string_view text) {
+  return predicate ? CaptureErrnoAsStatus(text) : error::kOkStatus;
 }
 
-}  // namespace error
+}  // namespace posix
 
-#endif  // LIB_ERROR_ERRNO_H_
+#endif  // LIB_POSIX_ERRNO_H_

--- a/lib/posix/errno_test.cc
+++ b/lib/posix/errno_test.cc
@@ -1,7 +1,8 @@
-#include "lib/error/errno.h"
+#include "lib/posix/errno.h"
 #include "gtest/gtest.h"
 
 using namespace error;
+using namespace posix;
 
 TEST(ErrnoTest, MakeCodeFromErrno) {
   EXPECT_EQ(std::make_error_code(std::errc::interrupted),

--- a/lib/posix/file_descriptor.h
+++ b/lib/posix/file_descriptor.h
@@ -1,0 +1,33 @@
+#ifndef LIB_POSIX_FILE_DESCRIPTOR_H_
+#define LIB_POSIX_FILE_DESCRIPTOR_H_
+
+#include "lib/base/opaque_value.h"
+
+namespace posix {
+
+// Strongly typed POSIX file descriptor wrapper.
+//
+// Example usage:
+//
+// FileDescriptor fd(open("/some/path", FLAGS));
+// ...
+// close(GetValue(fd));  // Wrapped value can be extracted.
+//
+DEFINE_OPAQUE_VALUE(int, FileDescriptor);
+
+// Canonical value to represent an invalid file descriptor.
+// Any negative value may be used but we prefer this one.
+constexpr FileDescriptor kInvalidFileDescriptor(-1);
+
+// Idiom to test for a valid looking file descriptor.
+//
+// No effort is made to check with the OS for a valid file descriptor. Any such
+// attempt is futile as there is an unavoidable time-of-check-to-time-of-use
+// race.
+inline constexpr bool IsWellFormed(const FileDescriptor fd) {
+  return 0 <= GetValue(fd);
+}
+
+}  // namespace posix
+
+#endif  // LIB_POSIX_FILE_DESCRIPTOR_H_

--- a/lib/posix/unique_file_descriptor.h
+++ b/lib/posix/unique_file_descriptor.h
@@ -1,0 +1,43 @@
+#ifndef LIB_POSIX_UNIQUE_FILE_DESCRIPTOR_H_
+#define LIB_POSIX_UNIQUE_FILE_DESCRIPTOR_H_
+
+#include "lib/base/ignore.h"
+#include "lib/base/unique_value.h"
+#include "lib/posix/close.h"
+#include "lib/posix/file_descriptor.h"
+
+namespace posix {
+namespace impl {
+
+struct UniqueFileDescriptorDtor {
+  void operator()(const FileDescriptor fd) {
+    if (IsWellFormed(fd)) {     // Sometimes an error gets wrapped.
+      base::Ignore(Close(fd));  // Nothing we can do about an error here.
+    }
+  }
+};
+
+}  // namespace impl
+
+// Type implementing a movable, automatically closing file descriptor. Use
+// UniqueFileDescriptor to represent owned FileDescriptors.
+//
+// A helper GetValue() is provided to access the wrapped value.
+// operator* is provided to access the wrapped value.
+// operator bool is provided to check for a wrapped value.
+//
+// See lib/base/unique_value.h for more implementation details.
+//
+// Example usage:
+// {
+//     UniqueFileDescriptor fd(open("/some/path", FLAGS));
+//     DoSomethingWithFd(GetValue(fd));  // Free function style value access.
+//     DoSomethingElseWithFd(*fd);  // std::unique_ptr style value access.
+// }  // 'fd' leaves scope and is automatically closed!
+//
+using UniqueFileDescriptor =
+    base::UniqueValue<FileDescriptor, impl::UniqueFileDescriptorDtor>;
+
+}  // namespace posix
+
+#endif  // LIB_POSIX_UNIQUE_FILE_DESCRIPTOR_H_

--- a/lib/posix/unique_file_descriptor_test.cc
+++ b/lib/posix/unique_file_descriptor_test.cc
@@ -3,8 +3,14 @@
 
 using namespace posix;
 
-TEST(UniqueFileDescriptorTest, DefaultConstruct) { UniqueFileDescriptor fd; }
+// UniqueFileDescriptor is written based on the assumtion that base::UniqueValue
+// is correct and well tested, therefore there isn't much to test here.
 
-TEST(UniqueFileDescriptorTest, Invalid) {
-  UniqueFileDescriptor fd(kInvalidFileDescriptor);
+TEST(UniqueFileDescriptorTest, DefaultConstructEmpty) {
+  UniqueFileDescriptor fd;
+  ASSERT_FALSE(fd);
+}
+
+TEST(UniqueFileDescriptor, CloseIsCalled) {
+  // TODO: find a way to mock calls to Close().
 }

--- a/lib/posix/unique_file_descriptor_test.cc
+++ b/lib/posix/unique_file_descriptor_test.cc
@@ -11,6 +11,10 @@ TEST(UniqueFileDescriptorTest, DefaultConstructEmpty) {
   ASSERT_FALSE(fd);
 }
 
+TEST(UniqueFileDescriptorTest, InvalidCausesDeath) {
+  ASSERT_DEATH({ UniqueFileDescriptor invalid(kInvalidFileDescriptor); }, "");
+}
+
 TEST(UniqueFileDescriptor, CloseIsCalled) {
   // TODO: find a way to mock calls to Close().
 }

--- a/lib/posix/unique_file_descriptor_test.cc
+++ b/lib/posix/unique_file_descriptor_test.cc
@@ -1,0 +1,10 @@
+#include "lib/posix/unique_file_descriptor.h"
+#include "gtest/gtest.h"
+
+using namespace posix;
+
+TEST(UniqueFileDescriptorTest, DefaultConstruct) { UniqueFileDescriptor fd; }
+
+TEST(UniqueFileDescriptorTest, Invalid) {
+  UniqueFileDescriptor fd(kInvalidFileDescriptor);
+}


### PR DESCRIPTION
These types provide typesafe file descriptors along with auto-closing
file descriptors to ease interaction with system libraries. First
party code should always use these types in preference to raw
integers.

posix::FileDescriptor is implemented in terms of OpaqueValue (existing).
posix::UniqueFileDescriptor is implemented in terms of UniqueValue (new).