### PR TITLE
Disable failing xdp_loader_test

### DIFF
--- a/lib/tests/xdp_loader_test.cc
+++ b/lib/tests/xdp_loader_test.cc
@@ -8,7 +8,10 @@ using namespace std;
 
 extern const char *argv[];
 
-TEST(XdpLoader, Test1) {
+// Currently unfixable with currently understood libbpf API.
+// TODO: bpf_object__open_buffer() does not allow specification of ifindex.
+// Without ifindex BPF_PROG_TYPE_XDP programs fail to load.
+TEST(XdpLoader, DISABLED_Test1) {
   // File is in ELF, we cannot really check it. Verify at least it is ELF.
   EXPECT_EQ(0, ebpf::sample.find("\x7f""ELF", 0));
   cout << "ebpf sample size " << ebpf::sample.size() << "\n";


### PR DESCRIPTION
Added a comment about why the test cannot be fixed.

Some noise was introduced by clang format.