### PR TITLE
Implement basic bpf() wrappers for map creation and program loading

### DIFF
--- a/lib/bpf/BUILD
+++ b/lib/bpf/BUILD
@@ -1,0 +1,35 @@
+cc_library(
+    name = "bpf",
+    hdrs = [
+        "bpf.h",
+        "map_create.h",
+        "map_lookup_element.h",
+        "map_update_element.h",
+        "prog_load.h",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//lib/base",
+        "//lib/posix",
+    ],
+)
+
+cc_test(
+    name = "prog_load_test",
+    srcs = ["prog_load_test.cc"],
+    deps = [
+        "//lib/bpf",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "map_test",
+    srcs = ["map_test.cc"],
+    deps = [
+        "//lib/bpf",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/lib/bpf/bpf.h
+++ b/lib/bpf/bpf.h
@@ -1,0 +1,20 @@
+#ifndef LIB_BPF_BPF_H_
+#define LIB_BPF_BPF_H_
+
+#include <sys/syscall.h>
+
+#include "lib/error/status_or.h"
+#include "lib/posix/syscall.h"
+
+namespace bpf {
+
+// bpf() syscall wrapper. No C standard library support currently exists.
+//
+// See "man 2 bpf" for details.
+inline error::StatusOr<int> Bpf(const int cmd, bpf_attr* const attr) {
+  return posix::Syscall(__NR_bpf, cmd, attr, sizeof(*attr));
+}
+
+}  // namespace bpf
+
+#endif  // LIB_BPF_BPF_H_

--- a/lib/bpf/map_create.h
+++ b/lib/bpf/map_create.h
@@ -1,0 +1,36 @@
+#ifndef LIB_BPF_MAP_CREATE_H_
+#define LIB_BPF_MAP_CREATE_H_
+
+#include <cstring>
+#include <string>
+#include <string_view>
+
+#include "lib/bpf/bpf.h"
+#include "lib/error/assign_or_return.h"
+#include "lib/error/status_or.h"
+#include "lib/posix/unique_file_descriptor.h"
+
+namespace bpf {
+
+// BPF_MAP_CREATE wrapper.
+// Create a map of 'map_type' from keys of type KeyT to values of type ValueT
+// and maximum capacity of 'max_entries'.
+//
+// Return an owned file descriptor on success or an error status on failure.
+//
+// See 'man 2 bpf' for details.
+template <typename KeyT, typename ValueT>
+inline error::StatusOr<posix::UniqueFileDescriptor> MapCreate(
+    const uint32_t map_type, const size_t max_entries) {
+  bpf_attr attr = {};
+  attr.map_type = map_type;
+  attr.key_size = sizeof(KeyT);
+  attr.value_size = sizeof(ValueT);
+  attr.max_entries = max_entries;
+  ASSIGN_OR_RETURN(const auto fd, Bpf(BPF_MAP_CREATE, &attr));
+  return posix::MakeUniqueFileDescriptor(fd);
+}
+
+}  // namespace bpf
+
+#endif  // LIB_BPF_MAP_CREATE_H_

--- a/lib/bpf/map_lookup_element.h
+++ b/lib/bpf/map_lookup_element.h
@@ -1,0 +1,33 @@
+#ifndef LIB_BPF_MAP_LOOKUP_ELEMENT_H_
+#define LIB_BPF_MAP_LOOKUP_ELEMENT_H_
+
+#include "lib/bpf/bpf.h"
+#include "lib/error/return_if_error.h"
+#include "lib/error/status_or.h"
+#include "lib/posix/file_descriptor.h"
+
+namespace bpf {
+
+// BPF_MAP_LOOKUP_ELEM wrapper.
+// Lookup an element identified by 'key' in the map identified by 'fd'.
+// The types of KeyT and ValueT must match those provided to MapCreate() when
+// 'fd' was created.
+//
+// Return the stored value on success or an error status on lookup failure.
+//
+// See 'man 2 bpf' for details.
+template <typename KeyT, typename ValueT>
+inline error::StatusOr<ValueT> MapLookupElement(const posix::FileDescriptor fd,
+                                                const KeyT& key) {
+  ValueT value = {};
+  bpf_attr attr = {};
+  attr.map_fd = GetValue(fd);
+  attr.key = reinterpret_cast<uintptr_t>(&key);
+  attr.value = reinterpret_cast<uintptr_t>(&value);
+  RETURN_IF_ERROR(GetStatus(Bpf(BPF_MAP_LOOKUP_ELEM, &attr)));
+  return value;
+}
+
+}  // namespace bpf
+
+#endif  // LIB_BPF_MAP_LOOKUP_ELEMENT_H_

--- a/lib/bpf/map_test.cc
+++ b/lib/bpf/map_test.cc
@@ -1,0 +1,25 @@
+#include <linux/bpf.h>
+
+#include "gtest/gtest.h"
+#include "lib/bpf/map_create.h"
+#include "lib/bpf/map_lookup_element.h"
+#include "lib/bpf/map_update_element.h"
+
+using namespace bpf;
+
+TEST(MapCreateTest, EndToEnd) {
+  using Key = int;
+  using Value = std::pair<int, int>;
+  constexpr size_t kMaxElements = 8;
+  auto map = MapCreate<Key, Value>(BPF_MAP_TYPE_HASH, kMaxElements);
+  ASSERT_TRUE(IsOk(map));
+  const auto fd = GetValue(std::move(map));
+  Key key = 400;
+  Value value = {600, 900};
+  const auto update = MapUpdateElement(*fd, key, value);
+  ASSERT_TRUE(IsOk(update));
+  const auto lookup = MapLookupElement<Key, Value>(*fd, key);
+  ASSERT_TRUE(IsOk(lookup));
+  ASSERT_EQ(value, GetValue(lookup));
+  ASSERT_TRUE(IsError(MapLookupElement<Key, Value>(*fd, 401)));
+}

--- a/lib/bpf/map_update_element.h
+++ b/lib/bpf/map_update_element.h
@@ -1,0 +1,31 @@
+#ifndef LIB_BPF_MAP_UPDATE_ELEMENT_H_
+#define LIB_BPF_MAP_UPDATE_ELEMENT_H_
+
+#include "lib/bpf/bpf.h"
+#include "lib/error/return_if_error.h"
+#include "lib/error/status.h"
+#include "lib/posix/file_descriptor.h"
+
+namespace bpf {
+
+// BPF_MAP_UPDATE_ELEM wrapper.
+// Insert or update an element identified by 'key' to hold 'value' in the map
+// identified by 'fd'. The types of KeyT and ValueT must match those provided
+// to MapCreate() when 'fd' was created.
+//
+// Return kOkStatus on success or an error status on failure.
+//
+// See 'man 2 bpf' for details.
+template <typename KeyT, typename ValueT>
+inline error::Status MapUpdateElement(const posix::FileDescriptor fd,
+                                      const KeyT& key, const ValueT& value) {
+  bpf_attr attr = {};
+  attr.map_fd = GetValue(fd);
+  attr.key = reinterpret_cast<uintptr_t>(&key);
+  attr.value = reinterpret_cast<uintptr_t>(&value);
+  return GetStatus(Bpf(BPF_MAP_UPDATE_ELEM, &attr));
+}
+
+}  // namespace bpf
+
+#endif  // LIB_BPF_MAP_UPDATE_ELEMENT_H_

--- a/lib/bpf/prog_load.h
+++ b/lib/bpf/prog_load.h
@@ -1,0 +1,42 @@
+#ifndef LIB_BPF_PROG_LOAD_H_
+#define LIB_BPF_PROG_LOAD_H_
+
+#include <cstring>
+#include <string>
+#include <string_view>
+
+#include "lib/bpf/bpf.h"
+#include "lib/error/assign_or_return.h"
+#include "lib/error/status_or.h"
+#include "lib/posix/ifindex.h"
+#include "lib/posix/unique_file_descriptor.h"
+
+namespace bpf {
+
+// BPF_PROG_LOAD wrapper.
+//
+// TODO: Incomplete.
+//
+// See 'man 2 bpf' for details.
+inline error::StatusOr<posix::UniqueFileDescriptor> ProgLoad(
+    const uint32_t program_type, std::string_view instructions,
+    const std::string& license, const uint32_t program_flags,
+    const std::string& name, const posix::IfIndex ifindex) {
+  constexpr size_t kInstructionSize = 8;
+  bpf_attr attr = {};
+  attr.prog_type = program_type;
+  attr.insn_cnt = instructions.size() / kInstructionSize;
+  attr.insns = reinterpret_cast<uintptr_t>(instructions.data());
+  attr.license = reinterpret_cast<uintptr_t>(license.c_str());
+  // TODO: Log buffer? Need std::span<char> equivalent.
+  // TODO: Kernel version? Only needed for perf programs?.
+  attr.prog_flags = program_flags;
+  strncpy(attr.prog_name, name.c_str(), sizeof(attr.prog_name));
+  attr.prog_ifindex = GetValue(ifindex);
+  ASSIGN_OR_RETURN(const auto fd, Bpf(BPF_PROG_LOAD, &attr));
+  return posix::MakeUniqueFileDescriptor(fd);
+}
+
+}  // namespace bpf
+
+#endif  // LIB_BPF_PROG_LOAD_H_

--- a/lib/bpf/prog_load_test.cc
+++ b/lib/bpf/prog_load_test.cc
@@ -1,0 +1,10 @@
+#include <linux/bpf.h>
+
+#include "gtest/gtest.h"
+#include "lib/bpf/prog_load.h"
+
+using namespace bpf;
+
+TEST(ProgLoadTest, Placeholder) {
+  // TODO: ProgLoad() is not yet complete.
+}

--- a/lib/posix/BUILD
+++ b/lib/posix/BUILD
@@ -7,6 +7,8 @@ cc_library(
         "close.h",
         "errno.h",
         "file_descriptor.h",
+        "ifindex.h",
+        "syscall.h",
         "unique_file_descriptor.h",
     ],
     visibility = [
@@ -32,6 +34,15 @@ cc_test(
     srcs = [
         "unique_file_descriptor_test.cc",
     ],
+    deps = [
+        "//lib/posix",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "syscall_test",
+    srcs = ["syscall_test.cc"],
     deps = [
         "//lib/posix",
         "@gtest//:gtest_main",

--- a/lib/posix/close.h
+++ b/lib/posix/close.h
@@ -10,6 +10,9 @@
 
 namespace posix {
 
+// close() syscall wrapper.
+//
+// See "man 2 close" for details.
 inline ::error::Status Close(const FileDescriptor fd) {
   const auto rv = ::close(GetValue(fd));
   return OkStatusOrCaptureErrnoIf(-1 == rv, "close() failed");

--- a/lib/posix/ifindex.h
+++ b/lib/posix/ifindex.h
@@ -1,0 +1,13 @@
+#ifndef LIB_POSIX_IFINDEX_H_
+#define LIB_POSIX_IFINDEX_H_
+
+#include "lib/base/opaque_value.h"
+
+namespace posix {
+
+// Strongly typed POSIX ifindex wrapper.
+DEFINE_OPAQUE_VALUE(int, IfIndex);
+
+}  // namespace posix
+
+#endif  // LIB_POSIX_IFINDEX_H_

--- a/lib/posix/syscall.h
+++ b/lib/posix/syscall.h
@@ -1,0 +1,26 @@
+#ifndef LIB_POSIX_SYSCALL_H_
+#define LIB_POSIX_SYSCALL_H_
+
+#include <unistd.h>
+
+#include "lib/error/return_if_error.h"
+#include "lib/error/status_or.h"
+#include "lib/posix/errno.h"
+#include "lib/posix/file_descriptor.h"
+
+namespace posix {
+
+// Trivial syscall wrapper. Checks for error conditions and converts errno to
+// error::Status. On success the returns the result of syscall().
+//
+// See 'man 2 syscall' for details.
+template <typename... ArgsT>
+inline error::StatusOr<int> Syscall(const int number, ArgsT&&... args) {
+  const auto rv = ::syscall(number, std::forward<ArgsT>(args)...);
+  RETURN_IF_ERROR(OkStatusOrCaptureErrnoIf(-1 == rv, "syscall() failed"));
+  return rv;
+}
+
+}  // namespace posix
+
+#endif  // LIB_POSIX_SYSCALL_H_

--- a/lib/posix/syscall_test.cc
+++ b/lib/posix/syscall_test.cc
@@ -1,0 +1,13 @@
+#include <sys/syscall.h>
+#include <sys/time.h>
+
+#include "gtest/gtest.h"
+#include "lib/posix/syscall.h"
+
+using namespace posix;
+
+TEST(SyscallTest, GetTimeOfDay) {
+  timeval tv = {};
+  auto status_or = Syscall(__NR_gettimeofday, &tv, nullptr);
+  EXPECT_TRUE(IsOk(status_or));
+}

--- a/lib/posix/unique_file_descriptor.h
+++ b/lib/posix/unique_file_descriptor.h
@@ -41,6 +41,14 @@ struct UniqueFileDescriptorDtor {
 using UniqueFileDescriptor =
     base::UniqueValue<FileDescriptor, impl::UniqueFileDescriptorDtor>;
 
+// Idiom to wrap a raw integer fd in a UniqueFileDescriptor.
+// Takes ownership of 'raw_fd'.
+inline UniqueFileDescriptor MakeUniqueFileDescriptor(const int raw_fd) {
+  const FileDescriptor fd(raw_fd);
+  INVARIANT_T(IsWellFormed(fd));
+  return UniqueFileDescriptor(fd);
+}
+
 }  // namespace posix
 
 #endif  // LIB_POSIX_UNIQUE_FILE_DESCRIPTOR_H_


### PR DESCRIPTION
Add a new cc_library target to hold bpf wrappers. Currently has a
working test for map create/insert/update/lookup. An incomplete
program load wrapper is present but untested.

Also add basic posix syscall infrastructure.