### PR TITLE
docker: add Docker template for a build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@ its supporting libraries, tools, and documentation.
 
 # Working on ebplane
 
+## Install development tools locally
 To work on ebplane, you must:
 
-1) Install bazel, by following the [instructions here](https://docs.bazel.build/versions/master/install.html).
+1) Install bazel, by following the [instructions here](https://docs.bazel.build/versions/master/install.html). 
+Make sure you install version [0.29.1](https://github.com/bazelbuild/bazel/releases/tag/0.29.1), 
+newer versions do not yet work.
 
 2) Build all the binaries, by running:
 
@@ -40,6 +43,13 @@ If you see the following error while building:
 On Ubuntu this can be resolved by installing:
 
    apt install gcc-multilib g++-multilib
+
+
+## Docker build container
+
+Instead of installing the build tools locally you could also use a docker 
+container that will install all the required tools. For more details see the
+[README.md](docker/README.md) in the docker folder.
 
 
 # Developing ebplane

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,88 @@
+#
+# Simple docker image which can be used as the ebplane dev environment
+#
+# Build the disk:
+#   $ docker build -t "ebplane_volume" .
+#
+#
+# Run the docker container and leave it running in the background (also map a
+# local folder in /scrah):
+#   $ docker run -P -h ebplane --name ebplane -d -v ~/Documents/Scratch:/scratch ebplane_volume
+#
+# Now you can access the running container either directly trough docker:
+#   $ docker exec -it ebplane bash
+#
+# Or via SSH, but you first need to get the local ssh port (password: ebplane):
+#   $ docker port ebplane 22
+#   0.0.0.0:32769
+#   $ ssh root@localhost -p 32768
+#
+#
+# Start the container as a one off to build and once done you exit:
+#   $ docker run -h ebplane -itv ~/Documents/Scratch:/scratch ebplane_volume bash
+#
+#
+#
+# NOTE: if enabled selinux might block access to your scratch directory:
+#         $ chcon -Rt svirt_sandbox_file_t ~/Documents/Scratch
+#
+
+#
+# Use latest Fedora distribution as base image
+#
+FROM fedora:latest
+
+
+#
+# Update existing packages, and install some additional ones
+#
+RUN dnf -y update && \
+    dnf -y install \ 
+	autoconf \
+	automake \
+	clang \
+	emacs-nox \
+	findutils \
+	gcc \
+	gcc-c++ \
+	gdb \
+	git \
+	glibc-devel.i686 \
+	make \
+	openssh-server \
+	unzip \
+	wget \
+	which \
+	zip \
+	zlib-devel
+
+
+#
+# Install Bazel v0.29.1 (any newer will currently not build ebPlane)
+#
+RUN wget https://github.com/bazelbuild/bazel/releases/download/0.29.1/bazel-0.29.1-installer-linux-x86_64.sh
+RUN chmod +x bazel-0.29.1-installer-linux-x86_64.sh
+RUN ./bazel-0.29.1-installer-linux-x86_64.sh
+
+
+#
+# Make sure you can access it trough SSH and end up in /scratch
+#
+RUN mkdir /var/run/sshd
+RUN echo 'root:ebplane' | chpasswd
+RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN /usr/bin/ssh-keygen -A
+
+
+#
+# Expose ssh port 22 and start the ssh daemon
+#
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]
+
+
+#
+# Auto move to the /scratch directory
+#
+VOLUME /scratch
+RUN echo "cd /scratch" >> /root/.bashrc

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,114 @@
+# Docker build container
+
+This directory contains a Docker definition file that can be used to get a 
+simple build environment setup. See the header in the [Dockerfile](Dockerfile)
+itself on various ways you could start and connect to the container.
+
+Below we will go through the basic steps on how to build the Docker volume, and
+container and successfully build and test the ebplane project.
+
+
+## Prerecuitistes on your host machine
+
+* First make sure Docker has been installed successfully
+* Secondly create the ~/Documents/Scratch directory and clone the ebplane project:
+
+```
+[host:~]$ mkdir ~/Documents/Scratch/
+[host:~]$ cd ~/Documents/Scratch/
+[host:~/Documents/Scratch]$ git clone https://github.com/Juniper/ebplane.git
+Cloning into 'ebplane'...
+remote: Enumerating objects: 14, done.
+remote: Counting objects: 100% (14/14), done.
+remote: Compressing objects: 100% (14/14), done.
+remote: Total 391 (delta 2), reused 6 (delta 0), pack-reused 377
+Receiving objects: 100% (391/391), 92.07 KiB | 736.00 KiB/s, done.
+Resolving deltas: 100% (190/190), done
+```
+
+
+## Build the Docker volume
+The below command creates the _ebplane\_volume_ which can be used later by the 
+Docker container.
+
+```
+[host:~]$ cd ~/Documents/Scratch/ebplane/docker
+[host:~/...ratch/ebplane/docker]$ docker build -t "ebplane_volume" .
+Sending build context to Docker daemon  5.632kB
+Step 1/13 : FROM fedora:latest
+ ---> c582c1438f27
+...
+...
+Step 13/13 : RUN echo "cd /scratch" >> /root/.bashrc
+ ---> Running in 327a5e0e968d
+Removing intermediate container 327a5e0e968d
+ ---> 5befe28e30eb
+Successfully built 5befe28e30eb
+Successfully tagged ebplane_volume:latest
+```
+
+## Start the Docker container
+
+We can start the container in the background and connect to it whenever needed,
+or start an instance and use it for the time being. See the header in the
+[Dockerfile](Dockerfile) for some examples. Here we will start a container and
+use it interactively.
+
+```
+[host:~/...ratch/ebplane/docker]$ docker run -h ebplane -itv ~/Documents/Scratch:/scratch ebplane_volume bash
+[root@ebplane scratch]# 
+```
+
+## Now build and run the unit tests
+
+Now that we are attached to the Docker container we can build all the binaries:
+
+```
+[root@ebplane scratch]# cd ebplane
+[root@ebplane ebplane]# bazel build ...:all
+Extracting Bazel installation...
+Starting local Bazel server and connecting to it...
+INFO: Analyzed 31 targets (37 packages loaded, 67557 targets configured).
+INFO: Found 31 targets...
+INFO: From CcGnumakeMakeRule external/linuxsrc/installhdr/include:
+
+INFO: From CcConfigureMakeRule external/elfutils/libelf/include:
+
+INFO: From CcGnumakeMakeRule external/libbpf/libbpf/include:
+
+INFO: Elapsed time: 246.150s, Critical Path: 83.71s
+INFO: 74 processes: 74 processwrapper-sandbox.
+INFO: Build completed successfully, 146 total actions
+```
+
+And finish it off with running the unit tests:
+
+```
+[root@ebplane ebplane]# bazel test ...:all
+INFO: Analyzed 31 targets (0 packages loaded, 0 targets configured).
+INFO: Found 15 targets and 16 test targets...
+INFO: Elapsed time: 2.438s, Critical Path: 0.18s
+INFO: 16 processes: 16 processwrapper-sandbox.
+INFO: Build completed successfully, 17 total actions
+//build/tests:ebpf_test                                                  PASSED in 0.0s
+//build/tests:embed_test_dependency                                      PASSED in 0.1s
+//build/tests:embed_test_library                                         PASSED in 0.0s
+//build/tests:embed_test_multiple                                        PASSED in 0.0s
+//build/tests:embed_test_simple                                          PASSED in 0.1s
+//daemon:main_test                                                       PASSED in 0.1s
+//lib/base:opaque_value_test                                             PASSED in 0.0s
+//lib/base:unique_value_test                                             PASSED in 0.0s
+//lib/error:assign_or_return_test                                        PASSED in 0.1s
+//lib/error:code_test                                                    PASSED in 0.0s
+//lib/error:return_if_error_test                                         PASSED in 0.0s
+//lib/error:status_or_test                                               PASSED in 0.0s
+//lib/error:status_test                                                  PASSED in 0.0s
+//lib/posix:errno_test                                                   PASSED in 0.0s
+//lib/posix:unique_file_descriptor_test                                  PASSED in 0.0s
+//lib/tests:xdp_loader_test                                              PASSED in 0.0s
+
+Executed 16 out of 16 tests: 16 tests pass.
+INFO: Build completed successfully, 17 total actions
+```
+
+


### PR DESCRIPTION
Add a Docker template that can be used as a build environment instead
of installing all build tools locally. It also includes documentation
on how to set it up, and use it.

Signed-off-by: Eelco Chaudron <echaudron@gmail.com>