### PR TITLE
Fix for loading xdp program through buffer

### DIFF
--- a/lib/ebpd.cc
+++ b/lib/ebpd.cc
@@ -1,11 +1,10 @@
 #include "lib/ebpd.h"
-#include "lib/ebpf/sample.h"
+#include "lib/ebpd_utils.h"
 
 #include <iostream>
 
-// This is just an example function.
-// The ebpf code is available as std::string_view named ebpf::sample.
-// ebpf::sample.data() and ebpf::sample.size() provide access to the bytecode.
-void func(void) {
-  std::cout << ebpf::sample.size() << std::endl;
+int InitEbpdLib(void) {
+    /* set the libbpf print function to ours */
+    ebpd_override_libbpf_print_func();
+    return 0;
 }

--- a/lib/ebpd.h
+++ b/lib/ebpd.h
@@ -1,4 +1,6 @@
 #ifndef LIB_EBPD_H_
 #define LIB_EBPD_H_
 
+int InitEbpdLib(void);
+
 #endif  // LIB_EBPD_H_

--- a/lib/ebpd_utils.h
+++ b/lib/ebpd_utils.h
@@ -23,6 +23,8 @@ extern int ebpd_load_xdp_buffer (void *buf, int buf_size, const char *name, void
  */
 extern void ebpd_unload (void *handle);
 
+extern void ebpd_override_libbpf_print_func (void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/lib/ebpf/sample.c
+++ b/lib/ebpf/sample.c
@@ -11,3 +11,6 @@ int xdp_pass(struct xdp_md *ctx)
     return XDP_PASS;
 }
 
+__section("license")
+char _license[] = "GPL";
+

--- a/lib/tests/xdp_loader_test.cc
+++ b/lib/tests/xdp_loader_test.cc
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include "lib/ebpf/sample.h"
+#include "lib/ebpd.h"
 #include "lib/xdp_loader.h"
 #include <iostream>
 #include <string_view>
@@ -8,11 +9,9 @@ using namespace std;
 
 extern const char *argv[];
 
-// Currently unfixable with currently understood libbpf API.
-// TODO: bpf_object__open_buffer() does not allow specification of ifindex.
-// Without ifindex BPF_PROG_TYPE_XDP programs fail to load.
-TEST(XdpLoader, DISABLED_Test1) {
+TEST(XdpLoader, Test1) {
   // File is in ELF, we cannot really check it. Verify at least it is ELF.
+  InitEbpdLib();
   EXPECT_EQ(0, ebpf::sample.find("\x7f""ELF", 0));
   cout << "ebpf sample size " << ebpf::sample.size() << "\n";
   XdpHandle xdph = LoadXdpBuffer(ebpf::sample, "ebpf_sample");


### PR DESCRIPTION

- Fix for loading xdp programs from buffer through libbpf

- Register custom print api with libbpf so that we can get all the debug
  print msgs from libbpf. The debug libbpf print api doesn't print LIBBPF_DEBUG
  level msgs.